### PR TITLE
Added centos7 install scripts for the svncterm bin

### DIFF
--- a/centos7/centos7-install.sh
+++ b/centos7/centos7-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+yum install git wget zlib-devel libvncserver-devel gnutls-devel libjpeg-devel -y
+wget https://raw.githubusercontent.com/proxmox/vncterm/master/glyphs.h
+cp ../svncterm.c .
+cp ../svncterm.h .
+gcc -O2 -g -o svncterm svncterm.c -Wall -Wno-deprecated-declarations -D_GNU_SOURCE -lvncserver -lnsl -lpthread -lz -ljpeg -lutil -lgnutls
+install -s -m 0755 svncterm /usr/bin/

--- a/centos7/standalone-centos7-install.sh
+++ b/centos7/standalone-centos7-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+yum install git wget zlib-devel libvncserver-devel gnutls-devel libjpeg-devel -y
+git clone https://github.com/dealfonso/svncterm.git
+cd svncterm
+wget https://raw.githubusercontent.com/proxmox/vncterm/master/glyphs.h
+gcc -O2 -g -o svncterm svncterm.c -Wall -Wno-deprecated-declarations -D_GNU_SOURCE -lvncserver -lnsl -lpthread -lz -ljpeg -lutil -lgnutls
+install -s -m 0755 svncterm /usr/bin/


### PR DESCRIPTION
- The standalone can be executed using: curl URL-TO-RAW-SCRIPT | sh -
- The normal install need the repository to be downloaded first
